### PR TITLE
fix: up task timeout to 2 minutes

### DIFF
--- a/src/Binary.ts
+++ b/src/Binary.ts
@@ -26,7 +26,7 @@ const context: Context = {
     dryRun: options.dryRun,
     filterRegex: options.regex ? RegExp(options.regex) : undefined,
     invertRegex: options.invert,
-    taskPool: new Pool({ limit: options.numWorkers }),
+    taskPool: new Pool({ limit: options.numWorkers, timeout: 120000 }),
 };
 
 // Create and register a cache if needed.


### PR DESCRIPTION
Up task timeout to 2 minutes instead of the default 10 seconds.