### PR TITLE
fix: set exit code when a task fails

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@flybywiresim/igniter",
-  "version": "1.1.4",
+  "version": "1.2.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@flybywiresim/igniter",
-      "version": "1.1.4",
+      "version": "1.2.2",
       "bin": {
         "igniter": "dist/binary.mjs"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flybywiresim/igniter",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "types": "dist/index.d.ts",
   "description": "An intelligent task runner written in Typescript.",
   "repository": {

--- a/src/Library/Contracts/Task.ts
+++ b/src/Library/Contracts/Task.ts
@@ -32,11 +32,6 @@ export enum TaskStatus {
      * If group, all sub-tasks skipped.
      */
     Skipped,
-
-    /**
-     * Only used for groups, one or more sub-tasks failed.
-     */
-    Warning,
 }
 
 export interface Task {

--- a/src/Library/Tasks/TaskOfTasks.ts
+++ b/src/Library/Tasks/TaskOfTasks.ts
@@ -33,7 +33,7 @@ export default class TaskOfTasks implements Task {
         if (this.tasks.every((task) => task.status === TaskStatus.Skipped)) return TaskStatus.Skipped;
         if (this.tasks.every((task) => task.status === TaskStatus.Failed)) return TaskStatus.Failed;
         if (this.tasks.some((task) => task.status === TaskStatus.Running)) return TaskStatus.Running;
-        if (this.tasks.some((task) => task.status === TaskStatus.Failed)) return TaskStatus.Warning;
+        if (this.tasks.some((task) => task.status === TaskStatus.Failed)) return TaskStatus.Failed;
         return TaskStatus.Success;
     }
 
@@ -68,7 +68,6 @@ export default class TaskOfTasks implements Task {
             if (s === TaskStatus.Success) return ['✓', chalk.green];
             if (s === TaskStatus.Skipped) return ['↪', chalk.gray];
             if (s === TaskStatus.Failed) return ['✖', chalk.red];
-            if (s === TaskStatus.Warning) return ['⚠', chalk.yellow];
             return ['⊙', chalk.magenta]; // Replaced with spinner :)
         })(this.status);
 

--- a/src/Renderer.ts
+++ b/src/Renderer.ts
@@ -16,7 +16,7 @@ export default async (task: Task, refreshRate = 100) => {
     if (refreshRate === 0) {
         await task.run();
         render();
-        if (task.status !== TaskStatus.Success) {
+        if (task.status === TaskStatus.Failed) {
             process.exitCode = 1;
         }
         return;
@@ -26,7 +26,7 @@ export default async (task: Task, refreshRate = 100) => {
     await task.run();
     clearInterval(interval);
     render();
-    if (task.status !== TaskStatus.Success) {
+    if (task.status === TaskStatus.Failed) {
         process.exitCode = 1;
     }
 };

--- a/src/Renderer.ts
+++ b/src/Renderer.ts
@@ -1,4 +1,4 @@
-import { Task } from './Library/Contracts/Task';
+import { Task, TaskStatus } from './Library/Contracts/Task';
 
 export default async (task: Task, refreshRate = 100) => {
     const spinner = ['◜', '◠', '◝', '◞', '◡', '◟'];
@@ -16,6 +16,9 @@ export default async (task: Task, refreshRate = 100) => {
     if (refreshRate === 0) {
         await task.run();
         render();
+        if (task.status !== TaskStatus.Success) {
+            process.exitCode = 1;
+        }
         return;
     }
 
@@ -23,4 +26,7 @@ export default async (task: Task, refreshRate = 100) => {
     await task.run();
     clearInterval(interval);
     render();
+    if (task.status !== TaskStatus.Success) {
+        process.exitCode = 1;
+    }
 };


### PR DESCRIPTION
Currently, when an instrument build fails, igniter still exits with a success code, which makes GitHub actions assume the build was successful. 
This PR aims to set the exit code to 1 when one or more tasks failed. Also removes the "Warning" status as it didn't seem to bring too much value (if one task of a group fails the whole build should fail as the plane/build is not usable the IMO). 

Feel free to add suggestions if your opinion differs ;)