### PR TITLE
fix: ExecTask never exiting when spawned process fails

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@flybywiresim/igniter",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@flybywiresim/igniter",
-      "version": "1.2.2",
+      "version": "1.2.3",
       "bin": {
         "igniter": "dist/binary.mjs"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flybywiresim/igniter",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "types": "dist/index.d.ts",
   "description": "An intelligent task runner written in Typescript.",
   "repository": {

--- a/src/Library/Tasks/ExecTask.ts
+++ b/src/Library/Tasks/ExecTask.ts
@@ -1,5 +1,4 @@
 import { exec } from 'child_process';
-import { promisify } from 'util';
 import GenericTask from './GenericTask';
 import { TaskStatus } from '../Contracts/Task';
 
@@ -12,7 +11,29 @@ export default class ExecTask extends GenericTask {
         const commands = typeof command === 'string' ? [command] : command;
         super(key, async () => {
             for await (const cmd of commands) {
-                const poolExec = this.context.taskPool.promise.wrap(promisify(exec));
+                const poolExec = this.context.taskPool.promise.wrap((execCmd) => new Promise((resolve, reject) => {
+                    const p = exec(execCmd);
+
+                    let stderr = '';
+                    p.stderr.on('data', (data) => {
+                        stderr += data;
+                    });
+
+                    p.on('exit', (code) => {
+                        p.stdout.destroy();
+                        p.stderr.destroy();
+
+                        if (code === 0) {
+                            resolve(code);
+                        } else {
+                            const err = new Error();
+
+                            (err as any).stderr = stderr;
+
+                            reject(err);
+                        }
+                    });
+                }));
 
                 const task = poolExec(cmd);
 

--- a/src/Library/Tasks/ExecTask.ts
+++ b/src/Library/Tasks/ExecTask.ts
@@ -1,6 +1,7 @@
 import { exec } from 'child_process';
 import GenericTask from './GenericTask';
 import { TaskStatus } from '../Contracts/Task';
+import ExecTaskError from './ExecTaskError';
 
 export default class ExecTask extends GenericTask {
     constructor(
@@ -26,11 +27,7 @@ export default class ExecTask extends GenericTask {
                         if (code === 0) {
                             resolve(code);
                         } else {
-                            const err = new Error();
-
-                            (err as any).stderr = stderr;
-
-                            reject(err);
+                            reject(new ExecTaskError(stderr));
                         }
                     });
                 }));

--- a/src/Library/Tasks/ExecTaskError.ts
+++ b/src/Library/Tasks/ExecTaskError.ts
@@ -1,0 +1,5 @@
+export default class ExecTaskError extends Error {
+    constructor(public readonly stderr: string) {
+        super('Error in ExecTask spawned process');
+    }
+}

--- a/src/Library/Tasks/GenericTask.ts
+++ b/src/Library/Tasks/GenericTask.ts
@@ -3,6 +3,7 @@ import chalk from 'chalk';
 import { TaskRunner, Task, TaskStatus } from '../Contracts/Task';
 import { generateHashFromPaths, storage } from '../../Helpers';
 import { Context } from '../Contracts/Context';
+import ExecTaskError from './ExecTaskError';
 
 export default class GenericTask implements Task {
     protected context: Context;
@@ -50,9 +51,15 @@ export default class GenericTask implements Task {
                 this.context.cache.set(taskKey, generateHash);
             }
         } catch (error) {
-            if (this.context.debug) throw error;
+            if (this.context.debug) {
+                throw error;
+            }
+
             this.status = TaskStatus.Failed;
-            if ('stderr' in error) this.errorOutput = error.stderr;
+
+            if (error instanceof ExecTaskError) {
+                this.errorOutput = error.stderr;
+            }
         }
     }
 

--- a/src/task-pool.d.ts
+++ b/src/task-pool.d.ts
@@ -38,7 +38,7 @@ declare module "task-pool" {
 
         queue: PoolTask<any>[]
 
-        wrap(Function, options?: Partial<PoolTaskOptions>): PoolTaskFactory<TPoolStyle>
+        wrap(Function: (...args: any[]) => Promise<any>, options?: Partial<PoolTaskOptions>): PoolTaskFactory<TPoolStyle>
 
         next()
 


### PR DESCRIPTION
This fixes an issue where, on certain platforms, `ExecTask`s would never exit if they had printed error output.