### PR TITLE
feat: multiple regexes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@flybywiresim/igniter",
-  "version": "1.2.3",
+  "version": "1.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@flybywiresim/igniter",
-      "version": "1.2.3",
+      "version": "1.3.0",
       "bin": {
         "igniter": "dist/binary.mjs"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flybywiresim/igniter",
-  "version": "1.2.3",
+  "version": "1.3.0",
   "types": "dist/index.d.ts",
   "description": "An intelligent task runner written in Typescript.",
   "repository": {

--- a/readme.md
+++ b/readme.md
@@ -10,19 +10,21 @@ npx igniter --help
 Usage: igniter [options]
 
 Options:
-  -V, --version                 output the version number
-  -c, --config <filename>       set the configuration file name (default:
-                                "igniter.config.mjs")
-  -j, --num-workers <number>    set the maximum number of workers to use
-                                (default: Number.MAX_SAFE_INTEGER)
-  -r, --regex <regex>           regular expression used to filter tasks, all
-                                must pass if multiple args
-  -i, --invert                  if true, previous regex will be used to reject
-                                tasks
-  --no-cache                    do not skip tasks, even if hash matches cache
-  --no-tty                      do not show updating output, just show a single
-                                render
-  -d, --dry-run                 skip all tasks to show configuration
-  --debug                       stop when an exception is thrown and show trace
-  -h, --help                    display help for command
+  -V, --version               output the version number
+  -c, --config <filename>     Set the configuration file name (default:
+                              "igniter.config.mjs")
+  -j, --num-workers <number>  Set the maximum number of workers to use
+                              (default: Number.MAX_SAFE_INTEGER)
+  -r, --regex <regex>         Regular expression used to filter tasks. When
+                              multiple regex arguments are supplied, only
+                              tasks that match all of the arguments will be
+                              run
+  -i, --invert                If true, the preceeding regex argument will be
+                              used to reject tasks instead
+  --no-cache                  Do not skip tasks, even if hash matches cache
+  --no-tty                    Do not show updating output, just show a single
+                              render
+  -d, --dry-run               Skip all tasks to show configuration
+  --debug                     Stop when an exception is thrown and show trace
+  -h, --help                  display help for command
 ```

--- a/readme.md
+++ b/readme.md
@@ -15,8 +15,10 @@ Options:
                                 "igniter.config.mjs")
   -j, --num-workers <number>    set the maximum number of workers to use
                                 (default: Number.MAX_SAFE_INTEGER)
-  -r, --regex <regex>           regular expression used to filter tasks
-  -i, --invert                  if true, regex will be used to reject tasks
+  -r, --regex <regex>           regular expression used to filter tasks, all
+                                must pass if multiple args
+  -i, --invert                  if true, previous regex will be used to reject
+                                tasks
   --no-cache                    do not skip tasks, even if hash matches cache
   --no-tty                      do not show updating output, just show a single
                                 render

--- a/src/Binary.ts
+++ b/src/Binary.ts
@@ -18,7 +18,7 @@ function addRegex(regex: string): FilterRegex[] {
 
 function addRegexInvert(): void {
     if (allRegex.length === 0) {
-        throw new Error('Cannot ignore the last regex when there are no regex args!');
+        throw new Error('Cannot invert the last regex when there are no regex args!');
     }
     allRegex[allRegex.length - 1].invert = true;
 }

--- a/src/Binary.ts
+++ b/src/Binary.ts
@@ -24,14 +24,15 @@ function addRegexInvert(): void {
 }
 
 const binary = (new Command()).version(version)
-    .option('-c, --config <filename>', 'set the configuration file name', 'igniter.config.mjs')
-    .option('-j, --num-workers <number>', 'set the maximum number of workers to use', `${Number.MAX_SAFE_INTEGER}`)
-    .option('-r, --regex <regex>', 'regular expression used to filter tasks, all must pass if multiple args', addRegex, [])
-    .option('-i, --invert', 'if true, previous regex will be used to reject tasks', addRegexInvert)
-    .option('--no-cache', 'do not skip tasks, even if hash matches cache')
-    .option('--no-tty', 'do not show updating output, just show a single render')
-    .option('-d, --dry-run', 'skip all tasks to show configuration')
-    .option('--debug', 'stop when an exception is thrown and show trace')
+    .option('-c, --config <filename>', 'Set the configuration file name', 'igniter.config.mjs')
+    .option('-j, --num-workers <number>', 'Set the maximum number of workers to use', `${Number.MAX_SAFE_INTEGER}`)
+    .option('-r, --regex <regex>', 'Regular expression used to filter tasks. When multiple regex arguments are supplied,'
+        + ' only tasks that match all of the arguments will be run', addRegex)
+    .option('-i, --invert', 'If true, the preceeding regex argument will be used to reject tasks instead', addRegexInvert)
+    .option('--no-cache', 'Do not skip tasks, even if hash matches cache')
+    .option('--no-tty', 'Do not show updating output, just show a single render')
+    .option('-d, --dry-run', 'Skip all tasks to show configuration')
+    .option('--debug', 'Stop when an exception is thrown and show trace')
     .parse(process.argv);
 
 const options = binary.opts();

--- a/src/Library/Contracts/Context.ts
+++ b/src/Library/Contracts/Context.ts
@@ -1,12 +1,16 @@
 import { Pool } from 'task-pool';
 import { Cache } from './Cache';
 
+export interface FilterRegex {
+    regex: RegExp,
+    invert: boolean,
+}
+
 export interface Context {
     debug: boolean,
     configPath: string,
     dryRun: boolean,
-    filterRegex: RegExp|undefined,
-    invertRegex: boolean,
+    filterRegex: FilterRegex[],
     cache?: Cache,
     taskPool: Pool,
 }

--- a/src/Library/Tasks/GenericTask.ts
+++ b/src/Library/Tasks/GenericTask.ts
@@ -68,10 +68,10 @@ export default class GenericTask implements Task {
     }
 
     protected shouldSkipRegex(taskKey: string) {
-        if (this.context.dryRun) return true;
-        if (this.context.filterRegex === undefined) return this.context.invertRegex;
-        const regexMatches = this.context.filterRegex.test(taskKey);
-        return this.context.invertRegex ? regexMatches : !regexMatches;
+        if (this.context.dryRun) {
+            return true;
+        }
+        return !this.context.filterRegex.every((r) => (r.regex.test(taskKey) ? !r.invert : r.invert));
     }
 
     protected shouldSkipCache(taskKey: string) {


### PR DESCRIPTION
Support multiple regex arguments. All of the regex must pass for the task to run. The -i flag ignores the previous regex arg (or errors if there are none).

This makes using regex with build.sh work properly again after https://github.com/flybywiresim/aircraft/pull/9369

Bumped the version in prep to tag a rel after this is merged, and then I can open a PR on the main repo.